### PR TITLE
Remove external link that no longer exists

### DIFF
--- a/doc/using_the_march_iv/how_to_view_live_data.rst
+++ b/doc/using_the_march_iv/how_to_view_live_data.rst
@@ -35,8 +35,4 @@ Launch with
 Configuration
 ^^^^^^^^^^^^^
 rqt_multiplot allows you to save a configuration that determines which plots are displayed in the ui.
-As configuring a configuration can be time consuming, we have created a :march:`configuration folder<march_launch/rqt_multiplot>` with commonly used configurations to easily visualize the data you want.
-
-If you have created an additional useful configuration, feel free to open a pull request to have it added to the folder.
-
 You can save and load configurations in the top right of the application.


### PR DESCRIPTION
## Description
Removed the part about the `rqt_multiplot` configurations located in the project-march/march repository.

## Changes
* Removed `rqt_multiplot` configuration link

<!-- Please don't forget to request for reviews -->
