### PR TITLE
Feature: documentation transition gait

### DIFF
--- a/doc/march_packages/march_gait_selection.rst
+++ b/doc/march_packages/march_gait_selection.rst
@@ -1,0 +1,70 @@
+.. _march-gait-selection-label:
+
+march_gait_selection
+====================
+
+Overview
+--------
+The march_gait_selection module is used provide the exoskeleton operating system with information to perform the
+requested gait. It uses the march-gait-files, which are parsed using the march-shared-classes, to gather this
+information in a standard format.
+
+Behavior
+--------
+The march-state-machine accepts or declines a gait request originating from the input device. If the gait is accepted
+by the state machine the request will be send to the march-gait-selection module using a subgait sequence. Within
+this node the gait and subgait data which corresponds with the requested gait will be collected. This more detailed
+information is send over to the hardware-interface part of the exoskeleton software.
+
+Transition-subgait
+^^^^^^^^^^^^^^^^^^
+Is is possible to transition between two matching named subgaits of two different gaits (for example between the right
+swing of the walk small and walk large). The gait-selection module is able to accomplish this if the requested
+gait/sub-gait format consists of an old and new gait name. This structure requires that both gait names have matching
+subgait names to use for the transition. The transition algorithm calculates a new trajectory using the two subgait
+trajectories. If this is executed correctly the new trajectory is translated to a subgait file which is eventually send
+to the hardware-interface part of the exoskeleton software.
+
+
+ROS API
+-------
+
+Nodes
+^^^^^
+*gait_selection_node* - Responsible for doing the thing.
+
+*perform_gait_action* - Responsible for doing the thing.
+
+
+Subscribed Topics
+^^^^^^^^^^^^^^^^^
+*/march/gait/perform* (:march: `march_shared_resources/action/GaitName <march_shared_resources/action/GaitName.action>`)
+  Receives requested subgait, with gait(s), originating from the march-state-machine.
+
+Published Topics
+^^^^^^^^^^^^^^^^
+*/march/gait/schedule* (:march: `march_shared_resources/action/Gait <march_shared_resources/action/Gait.action>`)
+  Send subgait data to the hardware interface of the exoskeleton software.
+
+Services
+^^^^^^^^
+*/march/gait_selection/get_version_map* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+  Returns the name of the gait_version map of the gait_selection.
+
+*/march/gait_selection/set_version_map* (:march: `march_shared_resources/srv/StringTrigger <march_shared_resources/srv/StringTrigger.srv>`)
+  Sets a new gait version map in the gait_selection.
+
+*/march/gait_selection/get_directory_structure* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+  Return the directory structure of the gait-files repository.
+
+*/march/gait_selection/update_default_versions* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+  Calls the update_default_versions function of the gait_selection.
+
+
+Parameters
+^^^^^^^^^^
+*march_gait_selection/gait_package* (*string*, default: ``march_gait_files``)
+ The package where the gait files are located.
+
+*march_gait_selection/gait_directory* (*string*, default: ``training-v``)
+ The directory where the gait files are located, relative to the above package.

--- a/doc/march_packages/march_gait_selection.rst
+++ b/doc/march_packages/march_gait_selection.rst
@@ -5,16 +5,17 @@ march_gait_selection
 
 Overview
 --------
-The march_gait_selection module is used provide the exoskeleton operating system with information to perform the
-requested gait. It uses the march-gait-files, which are parsed using the march-shared-classes, to gather this
-information in a standard format.
+The march_gait_selection module provides the exoskeleton operating system with gait-specific information to perform the
+requested movement. It uses the march-gait-files, which are parsed using the march-shared-classes, to gather this
+information in a standard format. These class objects are stored as attributes in the gait-selection object. The gait
+selection node can use this gait-selection object to extract the data corresponding to the requested gait/subgait name.
 
 Behavior
 --------
 The march-state-machine accepts or declines a gait request originating from the input device. If the gait is accepted
-by the state machine the request will be send to the march-gait-selection module using a subgait sequence. Within
-this node the gait and subgait data which corresponds with the requested gait will be collected. This more detailed
-information is send over to the hardware-interface part of the exoskeleton software.
+by the state machine the request will be send over to the march-gait-selection module using the subgait sequence defined
+in the state machine. The gait selection module will extract the data from the parsed gaits, if possible, and if executed
+correctly, will send the required data in a new format to the hardware-interface/simulation part of the exoskeleton software.
 
 Transition-subgait
 ^^^^^^^^^^^^^^^^^^
@@ -38,26 +39,26 @@ Nodes
 
 Subscribed Topics
 ^^^^^^^^^^^^^^^^^
-*/march/gait/perform* (:march: `march_shared_resources/action/GaitName <march_shared_resources/action/GaitName.action>`)
+*/march/gait/perform* (:march:`march_shared_resources/action/GaitName <march_shared_resources/action/GaitName.action>`)
   Receives requested subgait, with gait(s), originating from the march-state-machine.
 
 Published Topics
 ^^^^^^^^^^^^^^^^
-*/march/gait/schedule* (:march: `march_shared_resources/action/Gait <march_shared_resources/action/Gait.action>`)
+*/march/gait/schedule* (:march:`march_shared_resources/action/Gait <march_shared_resources/action/Gait.action>`)
   Send subgait data to the hardware interface of the exoskeleton software.
 
 Services
 ^^^^^^^^
-*/march/gait_selection/get_version_map* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+*/march/gait_selection/get_version_map* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
   Returns the name of the gait_version map of the gait_selection.
 
-*/march/gait_selection/set_version_map* (:march: `march_shared_resources/srv/StringTrigger <march_shared_resources/srv/StringTrigger.srv>`)
+*/march/gait_selection/set_version_map* (:march:`march_shared_resources/srv/StringTrigger <march_shared_resources/srv/StringTrigger.srv>`)
   Sets a new gait version map in the gait_selection.
 
-*/march/gait_selection/get_directory_structure* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+*/march/gait_selection/get_directory_structure* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
   Return the directory structure of the gait-files repository.
 
-*/march/gait_selection/update_default_versions* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`)
+*/march/gait_selection/update_default_versions* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
   Calls the update_default_versions function of the gait_selection.
 
 

--- a/doc/march_packages/march_gait_selection.rst
+++ b/doc/march_packages/march_gait_selection.rst
@@ -5,27 +5,28 @@ march_gait_selection
 
 Overview
 --------
-The march_gait_selection module provides the exoskeleton operating system with gait-specific information to perform the
-requested movement. It uses the march-gait-files, which are parsed using the march-shared-classes, to gather this
-information in a standard format. These class objects are stored as attributes in the gait-selection object. The gait
-selection node can use this gait-selection object to extract the data corresponding to the requested gait/subgait name.
+The march_gait_selection module provides the exoskeleton operating system with additional information about a gait in
+order to perform the requested movement. It uses the march_gait_files, which are parsed using the march_shared_classes,
+to gather this information in a standard format. These class objects are stored as attributes in the ``GaitSelection``
+object. The gait selection node can use this ``GaitSelection`` object to extract the data corresponding to the requested
+gait/subgait name.
 
 Behavior
 --------
-The march-state-machine accepts or declines a gait request originating from the input device. If the gait is accepted
-by the state machine the request will be send over to the march-gait-selection module using the subgait sequence defined
-in the state machine. The gait selection module will extract the data from the parsed gaits, if possible, and if executed
-correctly, will send the required data in a new format to the hardware-interface or simulation part of the exoskeleton
-software.
+The march_state_machine accepts or declines a gait request originating from the input device. If the gait is accepted
+by the state machine the request will be send over to the march_gait_selection module using the subgait sequence defined
+in the state machine. The gait selection module will extract the data from the parsed gaits, found in the
+``GaitSelection``, in order to perform the movement. If executed correctly a subgait trajectories will be sent over to
+the march_gait_scheduler of the exoskeleton.
 
-Transition-subgait
+Transition_subgait
 ^^^^^^^^^^^^^^^^^^
 It is possible to transition between two matching named subgaits of two different gaits (for example between the right
-swing of the walk small and walk large). The gait-selection module is able to accomplish this if the requested
-gait/sub-gait format consists of an old and new gait name. This structure requires that both gait names have matching
-subgait names to use for the transition. The transition algorithm calculates a new trajectory using the two subgait
-trajectories. If this is calculated correctly the new trajectory is translated to a subgait file which is eventually
-send to the hardware-interface or simulation part of the exoskeleton software.
+swing of the walk small and walk large). The gait_selection module will create a transition trajectory if the requested
+gait format, found in :march:`GaitName <march_shared_resources/action/GaitName.action>`, consists
+of an old and new gait name. This structure requires that both gait names have matching subgait names to use for the
+transition. Using the two subgait trajectories a new transition trajectory is calculated and stored as a subgait object.
+If this is calculated correctly the new subgait trajectory is sent to the march_gait_scheduler.
 
 
 ROS API
@@ -33,35 +34,35 @@ ROS API
 
 Nodes
 ^^^^^
-*gait_selection_node* - Responsible for doing the thing.
-
-*perform_gait_action* - Responsible for doing the thing.
+*gait_selection_node* - Responsible for adding gait file information to the gait request.
 
 
 Subscribed Topics
 ^^^^^^^^^^^^^^^^^
 */march/gait/perform* (:march:`march_shared_resources/action/GaitName <march_shared_resources/action/GaitName.action>`)
-  Receives requested subgait, with gait(s), originating from the march-state-machine.
+  Receives requested subgait, with gait(s), originating from the march_state_machine.
 
 Published Topics
 ^^^^^^^^^^^^^^^^
 */march/gait/schedule* (:march:`march_shared_resources/action/Gait <march_shared_resources/action/Gait.action>`)
-  Send subgait data to the hardware interface of the exoskeleton software.
+  Sends subgait trajectories to the march_gait_scheduler
 
 Services
 ^^^^^^^^
 */march/gait_selection/get_version_map* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
-  Returns the name of the gait_version map of the gait_selection.
+  Returns the current loaded gait version map.
 
 */march/gait_selection/set_version_map* (:march:`march_shared_resources/srv/StringTrigger <march_shared_resources/srv/StringTrigger.srv>`)
   Sets a new gait version map in the gait_selection.
 
 */march/gait_selection/get_directory_structure* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
-  Return the directory structure of the gait-files repository.
+  Returns the directory structure of the gait_files repository.
 
 */march/gait_selection/update_default_versions* (`std_srvs/srv/Trigger <http://docs.ros.org/melodic/api/std_srvs/html/srv/Trigger.html>`_)
   Calls the update_default_versions function of the gait_selection.
 
+*/march/gait_selection/contains_gait* (:march:`march_shared_resources/srv/ContainsGait <march_shared_resources/srv/ContainsGait.srv>`)
+  Checks if gait is in parsed gaits in the gait selection module.
 
 Parameters
 ^^^^^^^^^^

--- a/doc/march_packages/march_gait_selection.rst
+++ b/doc/march_packages/march_gait_selection.rst
@@ -15,16 +15,17 @@ Behavior
 The march-state-machine accepts or declines a gait request originating from the input device. If the gait is accepted
 by the state machine the request will be send over to the march-gait-selection module using the subgait sequence defined
 in the state machine. The gait selection module will extract the data from the parsed gaits, if possible, and if executed
-correctly, will send the required data in a new format to the hardware-interface/simulation part of the exoskeleton software.
+correctly, will send the required data in a new format to the hardware-interface or simulation part of the exoskeleton
+software.
 
 Transition-subgait
 ^^^^^^^^^^^^^^^^^^
-Is is possible to transition between two matching named subgaits of two different gaits (for example between the right
+It is possible to transition between two matching named subgaits of two different gaits (for example between the right
 swing of the walk small and walk large). The gait-selection module is able to accomplish this if the requested
 gait/sub-gait format consists of an old and new gait name. This structure requires that both gait names have matching
 subgait names to use for the transition. The transition algorithm calculates a new trajectory using the two subgait
-trajectories. If this is executed correctly the new trajectory is translated to a subgait file which is eventually send
-to the hardware-interface part of the exoskeleton software.
+trajectories. If this is calculated correctly the new trajectory is translated to a subgait file which is eventually
+send to the hardware-interface or simulation part of the exoskeleton software.
 
 
 ROS API

--- a/index.rst
+++ b/index.rst
@@ -117,4 +117,5 @@ The structure of this documentation is heavily inspired by that of `MoveIt! <htt
   doc/march_packages/march_shared_classes
   doc/march_packages/march_shared_resources
   doc/march_packages/march_state_machine
+  doc/march_packages/march_gait_selection
   doc/march_packages/march_simulation


### PR DESCRIPTION
Closes PM-351

## Description
This PR provides information about the transition subgait as well as the functionalities of the gait selection module. This PR includes the documentation about the gait selection since this was not yet written within the tutorials.  

## Changes
* Information about the gait selection module
* Information about the use of the transition subgait within the gait selection module
